### PR TITLE
Add a pelias user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,10 @@ ENV NODE_PATH="/usr/local/lib/node_modules:$NODE_PATH"
 
 # get ready for pelias config with an empty file
 ENV PELIAS_CONFIG '/code/pelias.json'
-RUN echo '{}' > /code/pelias.json
+RUN echo '{}' > '/code/pelias.json'
+
+# add a pelias user
+RUN useradd -ms /bin/bash pelias
+
+# ensure symlinks, pelias.json, and anything else are owned by pelias user
+RUN chown pelias:pelias /data /code -R


### PR DESCRIPTION
For security reasons, it's important that Docker containers run processes as non-root users where possible. After all, processes in a Docker container are just regular Linux processes, and we wouldn't run Pelias processes as the root user outside of Docker.

This PR adds a `pelias` user, which is available for running processes later.

Because images built with this baseimage may need to install additional dependencies, we can't run the `USER pelias` Docker command here, so each of our services/importers needs to do that.

That means this PR should effectively be a no-op until individual services and importers opt-in to using a non-root user.