### PR TITLE
Add python to baseimage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ ENV DEBIAN_FRONTEND 'noninteractive'
 # update apt, install core apt dependencies and delete the apt-cache
 # note: this is done in one command in order to keep down the size of intermediate containers
 RUN apt-get update && \
-    apt-get install -y locales iputils-ping curl wget git-core && \
+    apt-get install -y locales iputils-ping curl wget git-core \
+    autoconf automake libtool pkg-config python && \
     rm -rf /var/lib/apt/lists/*
 
 # configure locale

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,8 @@ ENV DEBIAN_FRONTEND 'noninteractive'
 
 # update apt, install core apt dependencies and delete the apt-cache
 # note: this is done in one command in order to keep down the size of intermediate containers
-RUN apt-get update && \
-    apt-get install -y locales iputils-ping curl wget git-core \
-    autoconf automake libtool pkg-config python && \
-    rm -rf /var/lib/apt/lists/*
+ADD packages.sh .
+RUN bash packages.sh
 
 # configure locale
 RUN locale-gen 'en_US.UTF-8'

--- a/packages.sh
+++ b/packages.sh
@@ -1,0 +1,16 @@
+packages=(
+"locales" # required for language support
+"iputils-ping"
+"curl"
+"wget"
+"git-core"
+"autoconf"
+"automake"
+"libtool"
+"pkg-config"
+"python" # required for node-gyp, in particular `integer` required by `better-sqlite3`
+)
+
+apt-get update && \
+  apt-get install -y ${packages[@]} && \
+  rm -rf /var/lib/apt/lists/*

--- a/packages.sh
+++ b/packages.sh
@@ -1,5 +1,6 @@
 packages=(
 "locales" # required for language support
+"apt-utils"
 "iputils-ping"
 "curl"
 "wget"


### PR DESCRIPTION
This is now required by all importers as of https://github.com/pelias/wof-admin-lookup/pull/194

Eventually, we can probably rearrange code to remove it.