### PR TITLE
Upgrade Node.js to version 10.13.0 (LTS)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN git config --global 'user.email' 'pelias.team@gmail.com'
 RUN git config --global 'user.name' 'Pelias Docker'
 
 # install nodejs
-ENV NODE_VERSION='8.11.4'
+ENV NODE_VERSION='10.13.0'
 RUN git clone 'https://github.com/isaacs/nave.git' /code/nave && /code/nave/nave.sh 'usemain' "${NODE_VERSION}" && rm -rf /code/nave
 
 # add global install dir to $NODE_PATH


### PR DESCRIPTION
I'm planning on merging this after 10.13.0 is released in a few days, and v10.0 becomes the LTS, recommended for production version of Node.js

We've been testing Node.js 10 quite a bit, up to and including full planet builds, and it's at least a little bit faster. JSON parsing seems especially faster, which is often a bottleneck for Pelias.

This is the PR to track in Node.js for when 10.13.0 is going to be released: https://github.com/nodejs/node/pull/23831