### PR TITLE
Remove nave cache directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN git config --global 'user.name' 'Pelias Docker'
 
 # install nodejs
 ENV NODE_VERSION='10.14.0'
-RUN git clone 'https://github.com/isaacs/nave.git' /code/nave && /code/nave/nave.sh 'usemain' "${NODE_VERSION}" && rm -rf /code/nave
+RUN git clone 'https://github.com/isaacs/nave.git' /code/nave && /code/nave/nave.sh 'usemain' "${NODE_VERSION}" && rm -rf ~/.nave /code/nave
 
 # add global install dir to $NODE_PATH
 ENV NODE_PATH="/usr/local/lib/node_modules:$NODE_PATH"


### PR DESCRIPTION
I was looking briefly at the output of [Anchore image analysis](https://anchore.io/image/dockerhub/pelias%2Fbaseimage:latest#changelog) for the baseimage, and noticed that nave is storing a cached copy of the Node.js archive.

This is 18MB and is not needed once installed, so it seems like an easy way to save some space.